### PR TITLE
Add support for outputting to files

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,7 +52,8 @@ pub fn main(opt: Opt) -> Result<(), Error> {
                         println!("Time: {:0.3}s", seconds + millis);
                     }
                     if !opt.skip_tuples {
-                        output.dump(tables);
+                        let mut stdout = ::std::io::stdout();
+                        output.dump(&mut stdout.lock(), tables).expect("Failed to write output");
                     }
                 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ use failure::Error;
 use std::time::{Duration, Instant};
 use structopt::StructOpt;
 
+use std::io;
 use std::path::PathBuf;
 
 arg_enum! {
@@ -26,6 +27,8 @@ pub struct Opt {
     skip_timing: bool,
     #[structopt(short = "v")]
     verbose: bool,
+    #[structopt(short = "o", long = "output")]
+    output_directory: Option<PathBuf>,
     #[structopt(raw(required = "true"))]
     fact_dirs: Vec<PathBuf>,
 }
@@ -52,8 +55,7 @@ pub fn main(opt: Opt) -> Result<(), Error> {
                         println!("Time: {:0.3}s", seconds + millis);
                     }
                     if !opt.skip_tuples {
-                        let mut stdout = ::std::io::stdout();
-                        output.dump(&mut stdout.lock(), tables).expect("Failed to write output");
+                        output.dump(&opt.output_directory, tables).expect("Failed to write output");
                     }
                 }
 

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -3,6 +3,7 @@ use crate::intern::*;
 use fxhash::FxHashMap;
 use std::collections::{BTreeMap, BTreeSet};
 use std::hash::Hash;
+use std::io::{self, Write};
 
 crate trait OutputDump {
     fn push_all(
@@ -13,9 +14,12 @@ crate trait OutputDump {
     );
 }
 
-crate fn dump_rows(title: &str, intern: &InternerTables, value: &impl OutputDump) {
-    println!("# {}", title);
-    println!();
+crate fn dump_rows(title: &str,
+                   stream: &mut Write,
+                   intern: &InternerTables,
+                   value: &impl OutputDump) -> io::Result<()> {
+    writeln!(stream, "# {}", title)?;
+    writeln!(stream, "")?;
 
     let mut rows = Vec::new();
     OutputDump::push_all(value, intern, &mut vec![], &mut rows);
@@ -37,8 +41,10 @@ crate fn dump_rows(title: &str, intern: &InternerTables, value: &impl OutputDump
         }
         string.push_str(last);
 
-        println!("{}", string);
+        writeln!(stream, "{}", string)?;
     }
+
+    Ok(())
 }
 
 impl<K, V> OutputDump for FxHashMap<K, V>

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -14,13 +14,9 @@ crate trait OutputDump {
     );
 }
 
-crate fn dump_rows(title: &str,
-                   stream: &mut Write,
+crate fn dump_rows(stream: &mut Write,
                    intern: &InternerTables,
                    value: &impl OutputDump) -> io::Result<()> {
-    writeln!(stream, "# {}", title)?;
-    writeln!(stream, "")?;
-
     let mut rows = Vec::new();
     OutputDump::push_all(value, intern, &mut vec![], &mut rows);
     let col_width: usize = rows.iter()

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -14,6 +14,7 @@ use crate::intern::InternerTables;
 use fxhash::FxHashMap;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::{self, Write};
 
 mod dump;
 mod timely;
@@ -48,14 +49,15 @@ impl Output {
         }
     }
 
-    crate fn dump(&self, intern: &InternerTables) {
-        dump::dump_rows("borrow_live_at", intern, &self.borrow_live_at);
+    crate fn dump<W: Write>(&self, stream: &mut W, intern: &InternerTables) -> io::Result<()> {
+        dump::dump_rows("borrow_live_at", stream, intern, &self.borrow_live_at)?;
 
         if self.dump_enabled {
-            dump::dump_rows("restricts", intern, &self.restricts);
-            dump::dump_rows("region_live_at", intern, &self.region_live_at);
-            dump::dump_rows("subset", intern, &self.subset);
+            dump::dump_rows("restricts", stream, intern, &self.restricts)?;
+            dump::dump_rows("region_live_at", stream, intern, &self.region_live_at)?;
+            dump::dump_rows("subset", stream, intern, &self.subset)?;
         }
+        Ok(())
     }
 
     crate fn borrows_in_scope_at(&self, location: Point) -> &[Loan] {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -15,6 +15,7 @@ use fxhash::FxHashMap;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{self, Write};
+use std::path::PathBuf;
 
 mod dump;
 mod timely;
@@ -49,15 +50,38 @@ impl Output {
         }
     }
 
-    crate fn dump<W: Write>(&self, stream: &mut W, intern: &InternerTables) -> io::Result<()> {
-        dump::dump_rows("borrow_live_at", stream, intern, &self.borrow_live_at)?;
+    crate fn dump(&self, output_dir: &Option<PathBuf>, intern: &InternerTables) -> io::Result<()> {
+        dump::dump_rows(&mut writer_for(output_dir, "borrow_live_at")?, intern, &self.borrow_live_at)?;
 
         if self.dump_enabled {
-            dump::dump_rows("restricts", stream, intern, &self.restricts)?;
-            dump::dump_rows("region_live_at", stream, intern, &self.region_live_at)?;
-            dump::dump_rows("subset", stream, intern, &self.subset)?;
+            dump::dump_rows(&mut writer_for(output_dir, "restricts")?, intern, &self.restricts)?;
+            dump::dump_rows(&mut writer_for(output_dir, "region_live_at")?, intern, &self.region_live_at)?;
+            dump::dump_rows(&mut writer_for(output_dir, "subset")?, intern, &self.subset)?;
         }
-        Ok(())
+        return Ok(());
+
+        fn writer_for(out_dir: &Option<PathBuf>, name: &str) -> io::Result<Box<Write>> {
+            // create a writer for the provided output.
+            // If we have an output directory use that, otherwise just dump to stdout
+            use std::fs;
+            use std::path::Path;
+
+            Ok(match out_dir {
+                Some(ref dir) => {
+                    if !dir.exists() {
+                        fs::create_dir(&dir)?;
+                    }
+                    let mut of = dir.join(name);
+                    of.set_extension("facts");
+                    Box::new(fs::File::create(of)?)
+                },
+                None => {
+                    let mut stdout = io::stdout();
+                    write!(&mut stdout, "# {}\n\n", name)?;
+                    Box::new(stdout)
+                }
+            })
+        }
     }
 
     crate fn borrows_in_scope_at(&self, location: Point) -> &[Loan] {


### PR DESCRIPTION
Does pretty much exactly what it says on the tin :smile:. Adds support for dumping the results to output files. We still dump to stdout by default, but now if `-o` or `--output` is provided that directory is used as the output directory. Different sets of facts are dumped to different files.