### PR TITLE
adopt extern-prelude and extern-absolute-path features

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,8 @@
+// macro `arg_enum!` uses some deprecated methods, and I can't find a
+// more targetd way to squelch the warnings:
+#![allow(deprecated)]
+
+use clap::{arg_enum, _clap_count_exprs};
 use crate::intern;
 use crate::output::Output;
 use crate::tab_delim;

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,4 +1,4 @@
-use facts::*;
+use crate::facts::*;
 use std::collections::HashMap;
 
 /// When we load facts out of the table, they are essentially random

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,13 @@
 #![feature(catch_expr)]
 #![feature(crate_in_paths)]
 #![feature(crate_visibility_modifier)]
+#![feature(extern_absolute_paths)]
+#![feature(extern_prelude)]
 #![feature(proc_macro)]
 #![feature(in_band_lifetimes)]
 #![feature(termination_trait_test)]
 
 #![allow(dead_code)]
-
-extern crate abomonation;
-extern crate abomonation_derive;
-extern crate differential_dataflow;
-extern crate failure;
-extern crate fxhash;
-extern crate timely;
-extern crate structopt;
-
-#[macro_use]
-extern crate clap;
 
 mod facts;
 mod intern;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,11 @@
-extern crate borrow_check;
-extern crate failure;
-extern crate structopt;
+#![feature(catch_expr)]
+#![feature(crate_in_paths)]
+#![feature(crate_visibility_modifier)]
+#![feature(extern_absolute_paths)]
+#![feature(extern_prelude)]
+#![feature(proc_macro)]
+#![feature(in_band_lifetimes)]
+#![feature(termination_trait_test)]
 
 use structopt::StructOpt;
 


### PR DESCRIPTION
Now we don't need the `extern crate`. Though the need to pull in "private" macros from clap is a bit lame, as is suddent appearance of "deprecated method" warnings. 