### PR TITLE
[WIP] Stop materializing placeholder liveness at all points

### DIFF
--- a/polonius-engine/src/output/liveness.rs
+++ b/polonius-engine/src/output/liveness.rs
@@ -10,7 +10,6 @@
 
 //! An implementation of the origin liveness calculation logic
 
-use std::collections::BTreeSet;
 use std::time::Instant;
 
 use crate::facts::FactTypes;
@@ -23,7 +22,7 @@ pub(super) fn compute_live_origins<T: FactTypes>(
     cfg_edge: &Relation<(T::Point, T::Point)>,
     var_maybe_partly_initialized_on_exit: Relation<(T::Variable, T::Point)>,
     output: &mut Output<T>,
-) -> Vec<(T::Origin, T::Point)> {
+) -> Relation<(T::Origin, T::Point)> {
     let timer = Instant::now();
     let mut iteration = Iteration::new();
 
@@ -151,20 +150,5 @@ pub(super) fn compute_live_origins<T: FactTypes>(
         }
     }
 
-    origin_live_on_entry.elements
-}
-
-pub(super) fn make_universal_regions_live<T: FactTypes>(
-    origin_live_on_entry: &mut Vec<(T::Origin, T::Point)>,
-    cfg_node: &BTreeSet<T::Point>,
-    universal_regions: &[T::Origin],
-) {
-    debug!("make_universal_regions_live()");
-
-    origin_live_on_entry.reserve(universal_regions.len() * cfg_node.len());
-    for &origin in universal_regions.iter() {
-        for &point in cfg_node.iter() {
-            origin_live_on_entry.push((origin, point));
-        }
-    }
+    origin_live_on_entry
 }

--- a/polonius-engine/src/output/mod.rs
+++ b/polonius-engine/src/output/mod.rs
@@ -191,23 +191,11 @@ impl<T: FactTypes> Output<T> {
             drop_of_var_derefs_origin: all_facts.drop_of_var_derefs_origin.clone(),
         };
 
-        let mut origin_live_on_entry = liveness::compute_live_origins(
+        let origin_live_on_entry = liveness::compute_live_origins(
             liveness_ctx,
             &cfg_edge,
             var_maybe_partly_initialized_on_exit,
             &mut result,
-        );
-
-        let cfg_node = cfg_edge
-            .iter()
-            .map(|&(point1, _)| point1)
-            .chain(cfg_edge.iter().map(|&(_, point2)| point2))
-            .collect();
-
-        liveness::make_universal_regions_live::<T>(
-            &mut origin_live_on_entry,
-            &cfg_node,
-            &all_facts.universal_region,
         );
 
         // 3) Borrow checking
@@ -221,8 +209,6 @@ impl<T: FactTypes> Output<T> {
         // variants, to after the pre-pass has made sure we actually need to compute the full
         // analysis. If these facts happened to be recorded in separate MIR walks, we might also
         // avoid generating those facts.
-
-        let origin_live_on_entry = origin_live_on_entry.into();
 
         // TODO: also flip the order of this relation's arguments in rustc
         // from `loan_invalidated_at(point, loan)` to `loan_invalidated_at(loan, point)`.

--- a/src/test.rs
+++ b/src/test.rs
@@ -17,8 +17,7 @@ use std::path::Path;
 fn test_facts(all_facts: &AllFacts, algorithms: &[Algorithm]) {
     let naive = Output::compute(all_facts, Algorithm::Naive, true);
 
-    // Check that the "naive errors" are a subset of the "insensitive
-    // ones".
+    // Check that the "naive errors" are a subset of the "insensitive ones".
     let insensitive = Output::compute(all_facts, Algorithm::LocationInsensitive, false);
     for (naive_point, naive_loans) in &naive.errors {
         match insensitive.errors.get(&naive_point) {
@@ -77,18 +76,37 @@ fn test_facts(all_facts: &AllFacts, algorithms: &[Algorithm]) {
     for &optimized_algorithm in algorithms {
         println!("Algorithm {:?}", optimized_algorithm);
         let opt = Output::compute(all_facts, optimized_algorithm, true);
-        // TMP: until we reach our correctness goals, deactivate some comparisons between variants
-        // assert_equal(&naive.loan_live_at, &opt.loan_live_at);
-        assert_equal(&naive.errors, &opt.errors);
-        assert_equal(&naive.subset_errors, &opt.subset_errors);
-        assert_equal(&naive.move_errors, &opt.move_errors);
+        assert_equal(
+            &naive.loan_live_at,
+            &opt.loan_live_at,
+            "naive vs opt loan_live_at",
+        );
+        assert_equal(&naive.errors, &opt.errors, "naive vs opt errors");
+        assert_equal(
+            &naive.subset_errors,
+            &opt.subset_errors,
+            "naive vs opt subset_errors",
+        );
+        assert_equal(
+            &naive.move_errors,
+            &opt.move_errors,
+            "naive vs opt move_errors",
+        );
     }
 
     // The hybrid algorithm gets the same errors as the naive version
     let opt = Output::compute(all_facts, Algorithm::Hybrid, true);
-    assert_equal(&naive.errors, &opt.errors);
-    assert_equal(&naive.subset_errors, &opt.subset_errors);
-    assert_equal(&naive.move_errors, &opt.move_errors);
+    assert_equal(&naive.errors, &opt.errors, "naive vs hybrid errors");
+    assert_equal(
+        &naive.subset_errors,
+        &opt.subset_errors,
+        "naive vs hybrid subset_errors",
+    );
+    assert_equal(
+        &naive.move_errors,
+        &opt.move_errors,
+        "naive vs hybrid move_errors",
+    );
 }
 
 fn test_fn(dir_name: &str, fn_name: &str, algorithm: Algorithm) -> Result<(), Box<dyn Error>> {
@@ -155,7 +173,7 @@ fn test_insensitive_errors() -> Result<(), Box<dyn Error>> {
     expected.insert(Point::from(24), vec![Loan::from(1)]);
     expected.insert(Point::from(50), vec![Loan::from(2)]);
 
-    assert_equal(&insensitive.errors, &expected);
+    assert_equal(&insensitive.errors, &expected, "insensitive errors");
     Ok(())
 }
 

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -8,13 +8,13 @@ use crate::intern::InternerTables;
 use crate::program::parse_from_program;
 
 /// Test that two values are equal, with a better error than `assert_eq`
-pub fn assert_equal<A>(expected_value: &A, actual_value: &A)
+pub fn assert_equal<A>(expected_value: &A, actual_value: &A, message: &str)
 where
     A: ?Sized + Debug + Eq,
 {
     // First check that they have the same debug text. This produces a better error.
     let expected_text = format!("{:#?}", expected_value);
-    assert_expected_debug(&expected_text, actual_value);
+    assert_expected_debug(&expected_text, actual_value, message);
 
     // Then check that they are `eq` too, for good measure.
     assert_eq!(expected_value, actual_value);
@@ -22,7 +22,7 @@ where
 
 /// Test that the debug output of `actual_value` is as expected. Gives
 /// a nice diff if things fail.
-pub fn assert_expected_debug<A>(expected_text: &str, actual_value: &A)
+pub fn assert_expected_debug<A>(expected_text: &str, actual_value: &A, message: &str)
 where
     A: ?Sized + Debug,
 {
@@ -47,7 +47,7 @@ where
         }
     }
 
-    panic!("debug comparison failed");
+    panic!("debug comparison failed: {}", message);
 }
 
 /// Builder for fact checking assertions
@@ -92,9 +92,13 @@ pub(crate) fn assert_checkers_match(checker_a: &FactChecker, checker_b: &FactChe
 }
 
 pub(crate) fn assert_outputs_match(output_a: &Output<LocalFacts>, output_b: &Output<LocalFacts>) {
-    assert_equal(&output_a.errors, &output_b.errors);
-    assert_equal(&output_a.subset_errors, &output_b.subset_errors);
-    assert_equal(&output_a.move_errors, &output_b.move_errors);
+    assert_equal(&output_a.errors, &output_b.errors, "errors");
+    assert_equal(
+        &output_a.subset_errors,
+        &output_b.subset_errors,
+        "subset_errors",
+    );
+    assert_equal(&output_a.move_errors, &output_b.move_errors, "move_errors");
 }
 
 impl FactChecker {


### PR DESCRIPTION
To align the code with the datalog rules, and clean up our ~laziness~ love for simplicity, we'd have to remove the workaround where we materialized liveness data for the placeholder origins to be live at all points, where we historically had more complex rules in our soufflé prototypes, involving `;` for every join ensuring an origin's liveness.

Doing that with datafrog is painful and verbose of course, but the point of opening this draft PR is for discussion during the next sprint. And see whether the cost is worth the gain.

While the `LocationInsensitive` and `Naive` uses are mostly straightforward cases of switching from `origin_live_on_entry(Origin1, TargetNode)` predicates to `(origin_live_on_entry(Origin1, TargetNode); placeholder(Origin1, _))` predicates by expanding the whole rule for each of the alternatives, the `Opt` variant contains more subtle cases (in addition to these simple but verbose ones).

Since the variant is trying to limit the subset TC to origins dying along an edge, detecting when liveness ends is required, and relies on many instances of `!origin_live_on_entry(Origin1, TargetNode)` antijoins. In some rules, there seems to be nothing required for these antijoins to support the now-missing materialization: some rules which were not applicable to placeholders (whether because of fact generation, or earlier-rules filtering them out) when they were present in `origin_live_on_entry`, still aren't.

For example, [Opt rule 14](https://github.com/rust-lang/polonius/blob/d8cb41f464431b42622408400c4ae83117f26108/polonius-engine/src/output/datafrog_opt.rs#L457-L472): 
```prolog
dead_borrow_region_can_reach_root((origin, point), loan) :-
  loan_issued_at(origin, loan, point),
  !origin_live_on_entry(origin, point).
```
No loans are issued in placeholders, this relation is the same whether they're present in `origin_live_on_entry` or not.

For others, like [Opt rule 3](https://github.com/rust-lang/polonius/blob/d8cb41f464431b42622408400c4ae83117f26108/polonius-engine/src/output/datafrog_opt.rs#L204-L236) which uses both polarities, it doesn't seem to be that simple:
```prolog
live_to_dying_regions(origin1, origin2, point1, point2) :-
  subset(origin1, origin2, point1),
  cfg_edge(point1, point2),
  (origin_live_on_entry(origin1, point2); placeholder_origin(origin1)),
  !origin_live_on_entry(origin2, point2).
```

If `origin2` is a placeholder, the antijoin would have previously eliminated it from `live_to_dying_regions`, but now it seems we'd need to add another predicate like so:
```prolog
live_to_dying_regions(origin1, origin2, point1, point2) :-
  subset(origin1, origin2, point1),
  cfg_edge(point1, point2),
  (origin_live_on_entry(origin1, point2); placeholder_origin(origin1)),
  !origin_live_on_entry(origin2, point2),
  !placeholder_origin(origin2).
```
otherwise `origin2` would be considered `dying` here !

And the translation rules would be:
- previous joins with `origin_live_on_entry` had an implicit union with a join to the `placeholder` relation, which now needs to be made explicit in the rules with an alternative predicate. That mechanically expands to the combinations of all alternatives (some rules like [Opt rule 10](https://github.com/rust-lang/polonius/blob/d8cb41f464431b42622408400c4ae83117f26108/polonius-engine/src/output/datafrog_opt.rs#L331-L393) have 2 such alternative predicates, and therefore 4 datafrog expansions, for a whopping 62 line piece of code) (these expansions are done in this PR, in all 3 variants, and were all done using leapjoins with either a "filter" or "extend" leaper, depending on the WF-ness of the resulting leapjoin. Note that this is operationally very similar since `placeholder_origin` is a single-value relation, there's only a single unit tuple `extend_with` leapers can find for the join; very `filter_with`-like)
- previous antijoins with `origin_live_on_entry` had an implicit antijoin with the `placeholder` relation, which now needs to be made explicit in the rules, with a new antijoin predicate. That mechanically expands to either a new leaper when leapjoins are used, or another intermediate relation when regular joins are used (_neither of which is done in this PR yet_).

The rustc UI test suite seems to behave similarly with and without this PR, so there may not be code which can exercise these subtleties, but at least we can talk about the theoretical aspects.

Does this seem correct to you all ? What do you think of the complexity this adds, versus the (hard to quantify, but I haven't really tried to do so for reals yet) gains ? (Maybe a macro based approach would be acceptable, or maybe more work in datapond to handle leapjoins and the most complicated rules could hide all of this under a proc macro veneer of simplicity 🌠 ). 

For easier review/analysis, there's a commit for each variant (and from there one can go see the complete resulting file to have an idea of the damage):
- `LocationInsensitive` https://github.com/rust-lang/polonius/pull/157/commits/d8cfac930040a5faa5261f9afd1077e57d11a6df
- `Naive` https://github.com/rust-lang/polonius/pull/157/commits/26a3966f36245684a9d0e8ca2041925fc2a24107
- `Opt` https://github.com/rust-lang/polonius/pull/157/commits/213c99619f19d9dc849c039f33c4fe9360c1d067

Let's discuss !