### PR TITLE
Make Polonius report any found errors by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ slower) -- these are the exact rules described in [the
 blogpost][post]. You can also use `-a LocationInsensitive` to use a
 location insensitive analysis (faster, but may yield spurious errors).
 
-By default, `cargo run` just prints timing. If you also want to see
-the results, try `--show-tuples` (which will show errors) and maybe
-`-v` (to show more intermediate computations). You can supply `--help`
-to get more docs.
+By default, `cargo run` will print any errors found, but otherwise
+just prints timing. If you also want to see successful results, try
+`--show-tuples` and maybe `-v` (to show more intermediate computations).
+You can supply `--help` to get more docs.
 
 ### How to generate your own inputs
 

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -19,9 +19,9 @@ slower) -- these are the exact rules described in [the
 blogpost][post]. You can also use `-a LocationInsensitive` to use a
 location insensitive analysis (faster, but may yield spurious errors).
 
-By default, `cargo run` just prints timing. If you also want to see
-the results, try `--show-tuples` (which will show errors) and maybe
-`-v` (to show more intermediate computations). You can supply `--help`
-to get more docs.
+By default, `cargo run` will print any errors found, but otherwise
+just prints timing. If you also want to see successful results, try
+`--show-tuples` and maybe `-v` (to show more intermediate computations).
+You can supply `--help` to get more docs.
 
 [post]: http://smallcultfollowing.com/babysteps/blog/2018/04/27/an-alias-based-formulation-of-the-borrow-checker/

--- a/polonius-engine/src/output/mod.rs
+++ b/polonius-engine/src/output/mod.rs
@@ -514,6 +514,10 @@ impl<T: FactTypes> Output<T> {
             None => Cow::Owned(BTreeMap::default()),
         }
     }
+
+    pub fn has_errors(&self) -> bool {
+        !(self.errors.is_empty() && self.move_errors.is_empty() && self.subset_errors.is_empty())
+    }
 }
 
 /// Compares errors reported by Naive implementation with the errors


### PR DESCRIPTION
It's a bit confusing that running Polonius on some Rust code that you know has a borrow error doesn't seem to actually do anything - it gives the impression that no analysis is performed by default.

This changes the behaviour to print error tuples by default if any are found, for a better experience. The old behaviour can be re-enabled by using `--no-show-tuples` to suppress tuple output even if errors are present.