### PR TITLE
Enrich gitignore file to exclude editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,16 @@
 /*/Cargo.lock
 /*/target/
 .DS_Store
+
+## Editor
+*.swp
+*.swo
+Session.vim
+.cproject
+.idea
+*.iml
+.vscode
+.project
+.favorites.json
+.settings/
+.vs/


### PR DESCRIPTION
When using CodeLLDB on vscode to debug, vscodes files are currently tracked. This PR add editor files to gitignore so that editor files are no longer tracked by git.